### PR TITLE
Client for limits can be inherit

### DIFF
--- a/pdevice.go
+++ b/pdevice.go
@@ -31,7 +31,7 @@ type Pdevice struct{
 
    Description  struct {   
       Limits    struct {   
-         Client     int `json:"client,omitempty"`
+         Client     string `json:"client,omitempty"`
          Dataport       string `json:"dataport,omitempty"`
          Datarule       string `json:"datarule,omitempty"`
          Disk          string `json:"disk,omitempty"`


### PR DESCRIPTION
This crashes any unmarshalling attempt if the description.limit.client field is "inherit".
