### PR TITLE
Provision updates

### DIFF
--- a/provision.go
+++ b/provision.go
@@ -48,7 +48,7 @@ type ProvModel struct {
 }
 
 func (m *ProvModel) GetPath() string {
-	return "manage/model"
+	return PROVISION_MANAGE_MODEL
 }
 
 // Find is a helper function for finding model with characteristics contained in string argument
@@ -66,7 +66,7 @@ func (m *ProvModel) Find(modelName, id string) ProvModel {
 	}
 
 	var headers = http.Header{}
-	result, err := ProvCall(m.GetPath()+"/"+modelName+"/"+id, VendorToken, "", "GET", false, headers)
+	result, err := ProvCall(m.GetPath()+modelName+"/"+id, VendorToken, "", "GET", false, headers)
 
 	if err != nil {
 		log.Printf("Finding model(id: %s) met some error %v", id, err)


### PR DESCRIPTION
I've made basically three changes:
1. Use the defined provision path, the original path didn't have have /provision/ in it which was causing queries to return a 404.  The extra slash was also an issue.
2. Implemented the pool to save fetched models.  I should be concurrent safe but I haven't tested it, just wrote it similar to an example.
3. Implemented error returns from the ProvRestModel interface.  This won't be backward compatible.
